### PR TITLE
Added exporting all memories as .zip

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,13 @@
 
 This is a fork intended to add functionality for exporting your memories as a .zip.
 
+New packages needed:
+
+- JSZip (version 3.10.1 worked)
+- FileSaver (version 2.0.5 worked)
+
+---
+
 # TooFake: a bereal viewer & client
 
 ### want to stalk your friends, family, or ex without posting your own bereal? </br> toofake gives the ability to view bereals and post custom bereals without ever having to click on that annoying notification

--- a/README.md
+++ b/README.md
@@ -1,14 +1,3 @@
-# Fork
-
-This is a fork intended to add functionality for exporting your memories as a .zip.
-
-New packages needed:
-
-- JSZip (version 3.10.1 worked)
-- FileSaver (version 2.0.5 worked)
-
----
-
 # TooFake: a bereal viewer & client
 
 ### want to stalk your friends, family, or ex without posting your own bereal? </br> toofake gives the ability to view bereals and post custom bereals without ever having to click on that annoying notification

--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+# Fork
+
+This is a fork intended to add functionality for exporting your memories as a .zip.
+
 # TooFake: a bereal viewer & client
 
 ### want to stalk your friends, family, or ex without posting your own bereal? </br> toofake gives the ability to view bereals and post custom bereals without ever having to click on that annoying notification

--- a/new/client/package-lock.json
+++ b/new/client/package-lock.json
@@ -18,10 +18,12 @@
         "@types/react-dom": "18.2.5",
         "@vercel/analytics": "^1.0.1",
         "axios": "^1.4.0",
+        "file-saver": "^2.0.5",
         "formidable": "^3.4.0",
         "heic-convert": "^1.2.4",
         "i18next": "^23.2.3",
         "jimp": "^0.22.8",
+        "jszip": "^3.10.1",
         "moment": "^2.29.4",
         "next": "13.4.6",
         "next-i18next": "^14.0.0",
@@ -35,6 +37,9 @@
         "sass": "^1.63.4",
         "sharp": "^0.32.1",
         "typescript": "5.1.3"
+      },
+      "devDependencies": {
+        "@types/file-saver": "^2.0.5"
       }
     },
     "node_modules/@babel/runtime": {
@@ -647,6 +652,12 @@
       "resolved": "https://registry.npmjs.org/@tokenizer/token/-/token-0.3.0.tgz",
       "integrity": "sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A=="
     },
+    "node_modules/@types/file-saver": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@types/file-saver/-/file-saver-2.0.5.tgz",
+      "integrity": "sha512-zv9kNf3keYegP5oThGLaPk8E081DFDuwfqjtiTzm6PoxChdJ1raSuADf2YGCVIyrSynLrgc8JWv296s7Q7pQSQ==",
+      "dev": true
+    },
     "node_modules/@types/formidable": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/@types/formidable/-/formidable-2.0.6.tgz",
@@ -960,6 +971,11 @@
         "url": "https://opencollective.com/core-js"
       }
     },
+    "node_modules/core-util-is": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ=="
+    },
     "node_modules/csstype": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.2.tgz",
@@ -1037,6 +1053,11 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/file-saver": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/file-saver/-/file-saver-2.0.5.tgz",
+      "integrity": "sha512-P9bmyZ3h/PRG+Nzga+rbdI4OEpNDzAVyy74uVO9ATgzLK6VtAsYybF/+TOCvrc0MO793d6+42lLyZTw7/ArVzA=="
     },
     "node_modules/file-type": {
       "version": "16.5.4",
@@ -1287,6 +1308,11 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-16.9.1.tgz",
       "integrity": "sha512-QpLcX9ZSsq3YYUUnD3nFDY8H7wctAhQj/TFKL8Ya8v5fMm3CFXxo8zStsLAl780ltoYoo1WvKUVGBQK+1ifr7g=="
     },
+    "node_modules/immediate": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
+      "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ=="
+    },
     "node_modules/immutable": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.3.0.tgz",
@@ -1350,6 +1376,11 @@
         "node": ">=0.12.0"
       }
     },
+    "node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ=="
+    },
     "node_modules/isomorphic-fetch": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-3.0.0.tgz",
@@ -1380,12 +1411,58 @@
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
     },
+    "node_modules/jszip": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.10.1.tgz",
+      "integrity": "sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==",
+      "dependencies": {
+        "lie": "~3.3.0",
+        "pako": "~1.0.2",
+        "readable-stream": "~2.3.6",
+        "setimmediate": "^1.0.5"
+      }
+    },
+    "node_modules/jszip/node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/jszip/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+    },
+    "node_modules/jszip/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
     "node_modules/libheif-js": {
       "version": "1.15.1",
       "resolved": "https://registry.npmjs.org/libheif-js/-/libheif-js-1.15.1.tgz",
       "integrity": "sha512-1nIVY1IFYLglxHPuLMqMBpjx4wigEEUVnSj2d3pRzeOjzKetwXlVejHJJgomZwEARu0PZ3HeGOW7ID/hZr13cg==",
       "engines": {
         "node": ">=8.0.0"
+      }
+    },
+    "node_modules/lie": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
+      "integrity": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
+      "dependencies": {
+        "immediate": "~3.0.5"
       }
     },
     "node_modules/load-bmfont": {
@@ -1857,6 +1934,11 @@
         "node": ">= 0.6.0"
       }
     },
+    "node_modules/process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
+    },
     "node_modules/prop-types": {
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
@@ -2087,6 +2169,11 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/setimmediate": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+      "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA=="
     },
     "node_modules/sharp": {
       "version": "0.32.1",
@@ -2849,6 +2936,12 @@
       "resolved": "https://registry.npmjs.org/@tokenizer/token/-/token-0.3.0.tgz",
       "integrity": "sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A=="
     },
+    "@types/file-saver": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@types/file-saver/-/file-saver-2.0.5.tgz",
+      "integrity": "sha512-zv9kNf3keYegP5oThGLaPk8E081DFDuwfqjtiTzm6PoxChdJ1raSuADf2YGCVIyrSynLrgc8JWv296s7Q7pQSQ==",
+      "dev": true
+    },
     "@types/formidable": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/@types/formidable/-/formidable-2.0.6.tgz",
@@ -3077,6 +3170,11 @@
       "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.31.0.tgz",
       "integrity": "sha512-NIp2TQSGfR6ba5aalZD+ZQ1fSxGhDo/s1w0nx3RYzf2pnJxt7YynxFlFScP6eV7+GZsKO95NSjGxyJsU3DZgeQ=="
     },
+    "core-util-is": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ=="
+    },
     "csstype": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.2.tgz",
@@ -3136,6 +3234,11 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
       "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg=="
+    },
+    "file-saver": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/file-saver/-/file-saver-2.0.5.tgz",
+      "integrity": "sha512-P9bmyZ3h/PRG+Nzga+rbdI4OEpNDzAVyy74uVO9ATgzLK6VtAsYybF/+TOCvrc0MO793d6+42lLyZTw7/ArVzA=="
     },
     "file-type": {
       "version": "16.5.4",
@@ -3311,6 +3414,11 @@
         }
       }
     },
+    "immediate": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
+      "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ=="
+    },
     "immutable": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.3.0.tgz",
@@ -3362,6 +3470,11 @@
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
       "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="
     },
+    "isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ=="
+    },
     "isomorphic-fetch": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-3.0.0.tgz",
@@ -3392,10 +3505,58 @@
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
     },
+    "jszip": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.10.1.tgz",
+      "integrity": "sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==",
+      "requires": {
+        "lie": "~3.3.0",
+        "pako": "~1.0.2",
+        "readable-stream": "~2.3.6",
+        "setimmediate": "^1.0.5"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "2.3.8",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+          "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
+          }
+        },
+        "safe-buffer": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+          "requires": {
+            "safe-buffer": "~5.1.0"
+          }
+        }
+      }
+    },
     "libheif-js": {
       "version": "1.15.1",
       "resolved": "https://registry.npmjs.org/libheif-js/-/libheif-js-1.15.1.tgz",
       "integrity": "sha512-1nIVY1IFYLglxHPuLMqMBpjx4wigEEUVnSj2d3pRzeOjzKetwXlVejHJJgomZwEARu0PZ3HeGOW7ID/hZr13cg=="
+    },
+    "lie": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
+      "integrity": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
+      "requires": {
+        "immediate": "~3.0.5"
+      }
     },
     "load-bmfont": {
       "version": "1.4.1",
@@ -3700,6 +3861,11 @@
       "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
       "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A=="
     },
+    "process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
+    },
     "prop-types": {
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
@@ -3859,6 +4025,11 @@
       "requires": {
         "lru-cache": "^6.0.0"
       }
+    },
+    "setimmediate": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+      "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA=="
     },
     "sharp": {
       "version": "0.32.1",

--- a/new/client/package.json
+++ b/new/client/package.json
@@ -19,10 +19,12 @@
     "@types/react-dom": "18.2.5",
     "@vercel/analytics": "^1.0.1",
     "axios": "^1.4.0",
+    "file-saver": "^2.0.5",
     "formidable": "^3.4.0",
     "heic-convert": "^1.2.4",
     "i18next": "^23.2.3",
     "jimp": "^0.22.8",
+    "jszip": "^3.10.1",
     "moment": "^2.29.4",
     "next": "13.4.6",
     "next-i18next": "^14.0.0",
@@ -36,5 +38,8 @@
     "sass": "^1.63.4",
     "sharp": "^0.32.1",
     "typescript": "5.1.3"
+  },
+  "devDependencies": {
+    "@types/file-saver": "^2.0.5"
   }
 }

--- a/new/client/pages/memories/index.tsx
+++ b/new/client/pages/memories/index.tsx
@@ -86,6 +86,8 @@ export default function Memories() {
         <div className={s.memories} onClick={() => downloadMemories()}>
             <button>download</button>
         </div>
+        
+        <canvas id="myCanvas" width="1000" height="1000"></canvas>
 
         </div>
 
@@ -127,6 +129,28 @@ async function downloadMemories() {
     zip.generateAsync({ type: 'blob' }).then(function (content) {
         FileSaver.saveAs(content, 'download.zip');
     });
+
+
+
+    // Merging images for combined view
+
+
+    let primaryImage = await createImageBitmap(await primary);
+    let secondaryImage = await createImageBitmap(await secondary);
+
+
+    var canvas = document.getElementById("myCanvas") as HTMLCanvasElement;
+    canvas.width = primaryImage.width;
+    canvas.height = primaryImage.height;
+
+    var context = canvas.getContext("2d");
+    var imageObj = new Image();
+    
+    context.drawImage(primaryImage, 0, 0)
+    context.drawImage(secondaryImage, 0, 0, 600, 600)
+
+    console.log(imageObj);
+    
 
 
 

--- a/new/client/pages/memories/index.tsx
+++ b/new/client/pages/memories/index.tsx
@@ -12,6 +12,7 @@ import Memory from '@/models/memory';
 import Draggable from 'react-draggable';
 import Memoire from '@/components/memoire/memoire';
 
+
 export default function Memories() {
 
     useCheck();
@@ -59,9 +60,14 @@ export default function Memories() {
 
             }
         ).catch((error) => {console.log(error);})
-    }, [])
+    }, []);
+
+    
 
     return (
+
+        <div>
+
         <div className={s.memories}>
             {
                 loading ? <div className={l.loader}></div> :
@@ -72,6 +78,15 @@ export default function Memories() {
                 })
             }
         </div>
+
+
+        <div className={s.memories}>
+            <button>download</button>
+        </div>
+
+        </div>
+
+        
     )
 
 }

--- a/new/client/pages/memories/index.tsx
+++ b/new/client/pages/memories/index.tsx
@@ -196,9 +196,18 @@ async function downloadMemories() {
 
         if (mergedImage) {
 
-            let primaryImage = await createImageBitmap(await primary);
-            let secondaryImage = await createImageBitmap(await secondary);
+            let primaryImage;
+            let secondaryImage;
 
+            // Error can happen here, InvalidStateError?
+            // Only happens on specific images
+            try {
+                primaryImage = await createImageBitmap(await primary);
+                secondaryImage = await createImageBitmap(await secondary);
+            } catch (e) {
+                console.log(`ERROR: Memory #${i} on ${memoryDate} could not be zipped due to the following:\n${e}`);
+                continue;
+            }
 
             canvas.width = primaryImage.width;
             canvas.height
@@ -235,7 +244,6 @@ async function downloadMemories() {
                 ctx.quadraticCurveTo(x, y + height, x, y + height - radius);
                 ctx.lineTo(x, y + radius);
                 ctx.quadraticCurveTo(x, y, x + radius, y);
-                ctx.lineTo(500, 500)
 
                 ctx.closePath();
 
@@ -271,7 +279,7 @@ async function downloadMemories() {
                 
                     // Save w/ zip name of current date
                     zip.generateAsync({ type: 'blob' }).then(function (content) {
-                        FileSaver.saveAs(content, `bereal-export-${new Date().toLocaleDateString().replace(/\//g, '-')}.zip`);
+                        FileSaver.saveAs(content, `bereal-export-${new Date().toLocaleString("en-us", {year:"2-digit", month:"2-digit", day:"2-digit"}).replace(/\//g, '-')}.zip`);
                     });
                     
                     // Reset status

--- a/new/client/pages/memories/index.tsx
+++ b/new/client/pages/memories/index.tsx
@@ -169,10 +169,6 @@ async function downloadMemories() {
         let dateString = memoryDate.toLocaleString('en-us', { dateStyle: 'long' })
 
 
-        console.log(`Zipping memory #${i+1}: ${memoryDate}`)
-
-
-
         // REPLACE WITH PROPER PROXY SETUP!
         // Fetch image data
         let primary = fetch("https://api.codetabs.com/v1/proxy?quest=" + memory.primary)
@@ -199,7 +195,6 @@ async function downloadMemories() {
         var canvas = document.getElementById("myCanvas") as HTMLCanvasElement;
 
         if (mergedImage) {
-            console.log("Running merge")
 
             let primaryImage = await createImageBitmap(await primary);
             let secondaryImage = await createImageBitmap(await secondary);
@@ -258,14 +253,13 @@ async function downloadMemories() {
         // Async stuff: Must have generateAsync in toBlob function to run in proper order
 
         canvas.toBlob(async (blob) => {
-            console.log("Running toBlob")
+
             if (blob && mergedImage) {
                 zip.file(`${monthString}/${dateString}.png`, blob)
             }
 
             // Only save if on last memory
             if (i == newmemories.length-1) {
-                console.log("Running generate")
 
                 // @ts-ignore: Object is possibly 'null'.
                 status.textContent += `, exporting .zip...`

--- a/new/client/pages/memories/index.tsx
+++ b/new/client/pages/memories/index.tsx
@@ -13,6 +13,10 @@ import Draggable from 'react-draggable';
 import Memoire from '@/components/memoire/memoire';
 
 
+
+// Made memories global for downloading (kinda ugly)
+let newmemories: Memory[] = [];
+
 export default function Memories() {
 
     useCheck();
@@ -35,8 +39,6 @@ export default function Memories() {
             async (response) => {
                 console.log(response.data);
                 let memorydata = response.data.data;
-
-                let newmemories: Memory[] = [];
 
                 async function createMemory(data: any) {
                     let newmemory = await Memory.create(data);
@@ -80,7 +82,7 @@ export default function Memories() {
         </div>
 
 
-        <div className={s.memories}>
+        <div className={s.memories} onClick={() => downloadMemories()}>
             <button>download</button>
         </div>
 
@@ -88,5 +90,39 @@ export default function Memories() {
 
         
     )
+
+}
+
+async function downloadMemories() {
+
+    // Last memory, example
+    let memory = newmemories[newmemories.length - 1];
+
+    console.log(memory);
+
+    // REPLACE WITH PROPER PROXY SETUP!
+    // Fetch image data
+    let request = await fetch("https://api.codetabs.com/v1/proxy?quest=" + memory.primary)
+
+
+
+    // Download image, adapted from https://stackoverflow.com/a/64441995/21809626
+    // Gets blob, creates anchor, simulates a download
+    let blob = await request.blob()
+
+    const url = window.URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.style.display = 'none';
+    a.href = url;
+    a.download = "image.jpg";
+    document.body.appendChild(a);
+    a.click();
+    document.body.removeChild(a);
+    window.URL.revokeObjectURL(url);
+
+
+
+    
+
 
 }

--- a/new/client/pages/memories/index.tsx
+++ b/new/client/pages/memories/index.tsx
@@ -62,62 +62,60 @@ export default function Memories() {
                 console.log(newmemories);
 
             }
-        ).catch((error) => {console.log(error);})
+        ).catch((error) => { console.log(error); })
     }, []);
 
-    
+
 
     return (
 
         <div>
 
-        <div className={s.memories}>
-            {
-                loading ? <div className={l.loader}></div> :
-                memories.map((memory, index) => {
-                    return (
-                        <Memoire memory={memory} key={index} />
-                    )
-                })
-            }
+            <div className={s.memories}>
+                {
+                    loading ? <div className={l.loader}></div> :
+                        memories.map((memory, index) => {
+                            return (
+                                <Memoire memory={memory} key={index} />
+                            )
+                        })
+                }
+            </div>
+
+
+            <div className={s.memories}>
+                <button onClick={() => downloadMemories()}>download</button>
+            </div>
+
+            <div>
+                <p></p>
+                <label>Export both primary and secondary separately</label>
+                <input type="checkbox" id="separate"></input>
+                <p></p>
+                <label>Export merged primary + secondary into one image</label>
+                <input type="checkbox" id="merged"></input>
+            </div>
+
+            <canvas id="myCanvas" width="1000" height="1000"></canvas>
+
         </div>
 
 
-        <div className={s.memories}>
-            <button onClick={() => downloadMemories()}>download</button>
-        </div>
-
-        <div>
-            <p></p>
-            <label>Export both primary and secondary separately</label>
-            <input type="checkbox" id="separate"></input>
-            <p></p>
-            <label>Export merged primary + secondary into one image</label>
-            <input type="checkbox" id="merged"></input>
-        </div>
-        
-        <canvas id="myCanvas" width="1000" height="1000"></canvas>
-
-        </div>
-
-        
     )
 
 }
 
 async function downloadMemories() {
 
-    
     // Note: this is JS code not TS which is why it's throwing an error but runs fine
 
     // @ts-ignore: Object is possibly 'null'.
     let separateImages = document.getElementById("separate").checked;
     // @ts-ignore: Object is possibly 'null'.
     let mergedImage = document.getElementById("merged").checked;
-    
 
 
-    console.log(`Separate: ${separateImages}, Merged: ${mergedImage}`)
+
 
 
     // Don't do anything if no boxes are checked
@@ -125,118 +123,131 @@ async function downloadMemories() {
         console.log("No export setting selected");
         return;
     }
-    
-    // Last memory, example
-    let memory = newmemories[newmemories.length - 1];
-    let date = new Date(memory.date);
-
-    // Date strings for folder/file names
-    let monthString = date.toLocaleString('en-us',{month:'long', year:'numeric'})
-    let dateString = date.toLocaleString('en-us', {dateStyle:'long'})
-
-
-
-    // REPLACE WITH PROPER PROXY SETUP!
-    // Fetch image data
-    let primary = fetch("https://api.codetabs.com/v1/proxy?quest=" + memory.primary)
-                  .then((result) => result.blob())
-
-    let secondary = fetch("https://api.codetabs.com/v1/proxy?quest=" + memory.secondary)
-                  .then((result) => result.blob())
-
-    
-
-    // Create zip w/ image, adapted from https://stackoverflow.com/a/49836948/21809626
-    // (Change this to use the matching extension)
-
-    // Zip (primary + secondary) 
 
     let zip = new JSZip();
 
-    if (separateImages) {
-        zip.file(`${monthString}/${dateString} -  primary.jpg`, primary)
-        zip.file(`${monthString}/${dateString} - secondary.jpg`, secondary)
-    }
+    // Loop through each memory
+    for (let i = 0; i < newmemories.length; i++) {
+
+        console.log(`Memory #${i+1}`)
+
+        let memory = newmemories[i];
+        let date = new Date(memory.date);
+
+        // Date strings for folder/file names
+        let monthString = date.toLocaleString('en-us', { month: 'long', year: 'numeric' })
+        let dateString = date.toLocaleString('en-us', { dateStyle: 'long' })
 
 
-    
-    // Merging images for combined view
-    
-    var canvas = document.getElementById("myCanvas") as HTMLCanvasElement;
-    if (mergedImage) {
-        console.log("Running merge")
-        let primaryImage = await createImageBitmap(await primary);
-        let secondaryImage = await createImageBitmap(await secondary);
+
+        // REPLACE WITH PROPER PROXY SETUP!
+        // Fetch image data
+        let primary = fetch("https://api.codetabs.com/v1/proxy?quest=" + memory.primary)
+            .then((result) => result.blob())
+
+        let secondary = fetch("https://api.codetabs.com/v1/proxy?quest=" + memory.secondary)
+            .then((result) => result.blob())
 
 
-        
-        canvas.width = primaryImage.width;
-        canvas.height
-         = primaryImage.height;
 
-        var ctx = canvas.getContext("2d");
-        var imageObj = new Image();
-        
-        // For dealing with error, bereal-style combined image
-        if (ctx) {
-            ctx.drawImage(primaryImage, 0, 0)
+        // Create zip w/ image, adapted from https://stackoverflow.com/a/49836948/21809626
+        // (Change this to use the matching extension)
 
-            // Rounded secondary image, adapted from https://stackoverflow.com/a/19593950/21809626
-
-            // Values relative to image size
-            let width = secondaryImage.width * 0.3;
-            let height = secondaryImage.height * 0.3;
-            let x = primaryImage.width * 0.03;
-            let y = primaryImage.height * 0.03;
-            let radius = 70;
+        // Zip (primary + secondary) 
 
 
-            ctx.beginPath();
-            ctx.moveTo(x + radius, y);
-            ctx.lineTo(x + width - radius, y);
-            ctx.quadraticCurveTo(x + width, y, x + width, y + radius);
-            ctx.lineTo(x + width, y + height - radius);
-            ctx.quadraticCurveTo(x + width, y + height, x + width - radius, y + height);
-            ctx.lineTo(x + radius, y + height);
-            ctx.quadraticCurveTo(x, y + height, x, y + height - radius);
-            ctx.lineTo(x, y + radius);
-            ctx.quadraticCurveTo(x, y, x + radius, y);
-            ctx.lineTo(500,500)
-
-            ctx.closePath();
-            
-            ctx.lineWidth = 20;
-            ctx.stroke();
-
-            ctx.fill()
-            ctx.clip()
-
-            ctx.drawImage(secondaryImage, x, y, width, height)
-        }    
-    }
-
-    
-    
-    // Save as zip
-    // Async stuff: Must have generateAsync in toBlob function to run in proper order
-
-    canvas.toBlob(async (blob) => {
-        console.log("Running toBlob")
-        if (blob && mergedImage) {
-            zip.file(`${monthString}/${dateString}.jpg`, blob)
+        if (separateImages) {
+            zip.file(`${monthString}/${dateString} -  primary.jpg`, primary)
+            zip.file(`${monthString}/${dateString} - secondary.jpg`, secondary)
         }
 
-        console.log("Running generate")
-        zip.generateAsync({ type: 'blob' }).then(function (content) {
-            FileSaver.saveAs(content, 'download.zip');
-        });
-        
-    });  
 
-        
-    
-    
-    
+
+        // Merging images for combined view
+
+        var canvas = document.getElementById("myCanvas") as HTMLCanvasElement;
+        if (mergedImage) {
+            console.log("Running merge")
+            let primaryImage = await createImageBitmap(await primary);
+            let secondaryImage = await createImageBitmap(await secondary);
+
+
+
+            canvas.width = primaryImage.width;
+            canvas.height
+                = primaryImage.height;
+
+            var ctx = canvas.getContext("2d");
+            var imageObj = new Image();
+
+            // For dealing with error, bereal-style combined image
+            if (ctx) {
+                ctx.drawImage(primaryImage, 0, 0)
+
+                // Rounded secondary image, adapted from https://stackoverflow.com/a/19593950/21809626
+
+                // Values relative to image size
+                let width = secondaryImage.width * 0.3;
+                let height = secondaryImage.height * 0.3;
+                let x = primaryImage.width * 0.03;
+                let y = primaryImage.height * 0.03;
+                let radius = 70;
+
+
+                ctx.beginPath();
+                ctx.moveTo(x + radius, y);
+                ctx.lineTo(x + width - radius, y);
+                ctx.quadraticCurveTo(x + width, y, x + width, y + radius);
+                ctx.lineTo(x + width, y + height - radius);
+                ctx.quadraticCurveTo(x + width, y + height, x + width - radius, y + height);
+                ctx.lineTo(x + radius, y + height);
+                ctx.quadraticCurveTo(x, y + height, x, y + height - radius);
+                ctx.lineTo(x, y + radius);
+                ctx.quadraticCurveTo(x, y, x + radius, y);
+                ctx.lineTo(500, 500)
+
+                ctx.closePath();
+
+                ctx.lineWidth = 20;
+                ctx.stroke();
+
+                ctx.fill()
+                ctx.clip()
+
+                ctx.drawImage(secondaryImage, x, y, width, height)
+            }
+        }
+
+
+
+        // Save as zip
+        // Async stuff: Must have generateAsync in toBlob function to run in proper order
+
+        canvas.toBlob(async (blob) => {
+            console.log("Running toBlob")
+            if (blob && mergedImage) {
+                zip.file(`${monthString}/${dateString}.jpg`, blob)
+            }
+
+            // Only save if on last memory
+            if (i == newmemories.length - 1) {
+                console.log("Running generate")
+                zip.generateAsync({ type: 'blob' }).then(function (content) {
+                    FileSaver.saveAs(content, 'download.zip');
+                });
+            }
+        });
+
+
+    }
+
+
+
+
+
+
+
+
 
 }
 

--- a/new/client/pages/memories/index.tsx
+++ b/new/client/pages/memories/index.tsx
@@ -83,8 +83,8 @@ export default function Memories() {
         </div>
 
 
-        <div className={s.memories} onClick={() => downloadMemories()}>
-            <button>download</button>
+        <div className={s.memories}>
+            <button onClick={() => downloadMemories()}>download</button>
         </div>
         
         <canvas id="myCanvas" width="1000" height="1000"></canvas>
@@ -177,7 +177,7 @@ async function downloadMemories() {
         ctx.fill()
         ctx.clip()
 
-        ctx.drawImage(secondaryImage, 0, 0, 600, 600)
+        ctx.drawImage(secondaryImage, x, y, secondaryImage.width * 0.3, secondaryImage.height * 0.3)
     }
 
     console.log(imageObj);

--- a/new/client/pages/memories/index.tsx
+++ b/new/client/pages/memories/index.tsx
@@ -125,7 +125,6 @@ async function downloadMemories() {
     zip.file(`${monthString}/${dateString} -  primary.jpg`, primary)
     zip.file(`${monthString}/${dateString} - secondary.jpg`, secondary)
 
-
     zip.generateAsync({ type: 'blob' }).then(function (content) {
         FileSaver.saveAs(content, 'download.zip');
     });
@@ -133,8 +132,6 @@ async function downloadMemories() {
 
 
     // Merging images for combined view
-
-
     let primaryImage = await createImageBitmap(await primary);
     let secondaryImage = await createImageBitmap(await secondary);
 
@@ -143,11 +140,45 @@ async function downloadMemories() {
     canvas.width = primaryImage.width;
     canvas.height = primaryImage.height;
 
-    var context = canvas.getContext("2d");
+    var ctx = canvas.getContext("2d");
     var imageObj = new Image();
     
-    context.drawImage(primaryImage, 0, 0)
-    context.drawImage(secondaryImage, 0, 0, 600, 600)
+    // for annoying 'context' error, bereal-style combined image
+    if (!(ctx == null)) {
+        ctx.drawImage(primaryImage, 0, 0)
+
+        // Rounded secondary image, adapted from https://stackoverflow.com/a/19593950/21809626
+
+        // Values relative to image size
+        let width = secondaryImage.width * 0.3;
+        let height = secondaryImage.height * 0.3;
+        let x = primaryImage.width * 0.03;
+        let y = primaryImage.height * 0.03;
+        let radius = 70;
+
+
+        ctx.beginPath();
+        ctx.moveTo(x + radius, y);
+        ctx.lineTo(x + width - radius, y);
+        ctx.quadraticCurveTo(x + width, y, x + width, y + radius);
+        ctx.lineTo(x + width, y + height - radius);
+        ctx.quadraticCurveTo(x + width, y + height, x + width - radius, y + height);
+        ctx.lineTo(x + radius, y + height);
+        ctx.quadraticCurveTo(x, y + height, x, y + height - radius);
+        ctx.lineTo(x, y + radius);
+        ctx.quadraticCurveTo(x, y, x + radius, y);
+        ctx.lineTo(500,500)
+
+        ctx.closePath();
+        
+        ctx.lineWidth = 20;
+        ctx.stroke();
+
+        ctx.fill()
+        ctx.clip()
+
+        ctx.drawImage(secondaryImage, 0, 0, 600, 600)
+    }
 
     console.log(imageObj);
     

--- a/new/client/pages/memories/index.tsx
+++ b/new/client/pages/memories/index.tsx
@@ -11,7 +11,8 @@ import Link from 'next/link';
 import Memory from '@/models/memory';
 import Draggable from 'react-draggable';
 import Memoire from '@/components/memoire/memoire';
-
+import JSZip from 'jszip';
+import FileSaver from 'file-saver';
 
 
 // Made memories global for downloading (kinda ugly)
@@ -102,27 +103,17 @@ async function downloadMemories() {
 
     // REPLACE WITH PROPER PROXY SETUP!
     // Fetch image data
-    let request = await fetch("https://api.codetabs.com/v1/proxy?quest=" + memory.primary)
-
-
-
-    // Download image, adapted from https://stackoverflow.com/a/64441995/21809626
-    // Gets blob, creates anchor, simulates a download
-    let blob = await request.blob()
-
-    const url = window.URL.createObjectURL(blob);
-    const a = document.createElement('a');
-    a.style.display = 'none';
-    a.href = url;
-    a.download = "image.jpg";
-    document.body.appendChild(a);
-    a.click();
-    document.body.removeChild(a);
-    window.URL.revokeObjectURL(url);
-
-
+    let request = fetch("https://api.codetabs.com/v1/proxy?quest=" + memory.primary)
+                  .then((result) => result.blob())
 
     
+    // Create zip w/ image, adapted from https://stackoverflow.com/a/49836948/21809626
+
+    let zip = new JSZip();
+    zip.file('folder/image.jpg', request)
+    zip.generateAsync({ type: 'blob' }).then(function (content) {
+        FileSaver.saveAs(content, 'download.zip');
+    });
 
 
 }

--- a/new/client/pages/memories/index.tsx
+++ b/new/client/pages/memories/index.tsx
@@ -120,14 +120,17 @@ async function downloadMemories() {
 
     // Create zip w/ image, adapted from https://stackoverflow.com/a/49836948/21809626
     // (Change this to use the matching extension)
-    let zip = new JSZip();
 
-    zip.file(`${monthString}/${dateString} -  primary.jpg`, primary)
-    zip.file(`${monthString}/${dateString} - secondary.jpg`, secondary)
+    // Zip (primary + secondary) 
 
-    zip.generateAsync({ type: 'blob' }).then(function (content) {
-        FileSaver.saveAs(content, 'download.zip');
-    });
+    // let zip = new JSZip();
+
+    // zip.file(`${monthString}/${dateString} -  primary.jpg`, primary)
+    // zip.file(`${monthString}/${dateString} - secondary.jpg`, secondary)
+
+    // zip.generateAsync({ type: 'blob' }).then(function (content) {
+    //     FileSaver.saveAs(content, 'download.zip');
+    // });
 
 
 
@@ -143,8 +146,8 @@ async function downloadMemories() {
     var ctx = canvas.getContext("2d");
     var imageObj = new Image();
     
-    // for annoying 'context' error, bereal-style combined image
-    if (!(ctx == null)) {
+    // For dealing with error, bereal-style combined image
+    if (ctx) {
         ctx.drawImage(primaryImage, 0, 0)
 
         // Rounded secondary image, adapted from https://stackoverflow.com/a/19593950/21809626
@@ -177,13 +180,32 @@ async function downloadMemories() {
         ctx.fill()
         ctx.clip()
 
-        ctx.drawImage(secondaryImage, x, y, secondaryImage.width * 0.3, secondaryImage.height * 0.3)
+        ctx.drawImage(secondaryImage, x, y, width, height)
     }
 
-    console.log(imageObj);
+    
     
 
+    
 
+    // Zip (combined primary+secondary)
+    
+    canvas.toBlob((blob) => {
+
+        if (blob) {
+            let zip = new JSZip();
+
+            zip.file(`${monthString}/${dateString}.jpg`, blob)
+        
+            zip.generateAsync({ type: 'blob' }).then(function (content) {
+                FileSaver.saveAs(content, 'download.zip');
+            });
+        }
+
+    });
+
+
+    
 
 
 }

--- a/new/client/pages/memories/index.tsx
+++ b/new/client/pages/memories/index.tsx
@@ -15,7 +15,7 @@ import JSZip from 'jszip';
 import FileSaver from 'file-saver';
 
 
-// Made memories global for downloading (kinda ugly)
+// Made memories global for downloading (kinda ugly..)
 let newmemories: Memory[] = [];
 
 export default function Memories() {
@@ -98,22 +98,37 @@ async function downloadMemories() {
 
     // Last memory, example
     let memory = newmemories[newmemories.length - 1];
+    let date = new Date(memory.date);
 
-    console.log(memory);
+    // Date strings for folder/file names
+    let monthString = date.toLocaleString('en-us',{month:'long', year:'numeric'})
+    let dateString = date.toLocaleString('en-us', {dateStyle:'long'})
+
+
 
     // REPLACE WITH PROPER PROXY SETUP!
     // Fetch image data
-    let request = fetch("https://api.codetabs.com/v1/proxy?quest=" + memory.primary)
+    let primary = fetch("https://api.codetabs.com/v1/proxy?quest=" + memory.primary)
+                  .then((result) => result.blob())
+
+    let secondary = fetch("https://api.codetabs.com/v1/proxy?quest=" + memory.secondary)
                   .then((result) => result.blob())
 
     
-    // Create zip w/ image, adapted from https://stackoverflow.com/a/49836948/21809626
 
+    // Create zip w/ image, adapted from https://stackoverflow.com/a/49836948/21809626
+    // (Change this to use the matching extension)
     let zip = new JSZip();
-    zip.file('folder/image.jpg', request)
+
+    zip.file(`${monthString}/${dateString} -  primary.jpg`, primary)
+    zip.file(`${monthString}/${dateString} - secondary.jpg`, secondary)
+
+
     zip.generateAsync({ type: 'blob' }).then(function (content) {
         FileSaver.saveAs(content, 'download.zip');
     });
+
+
 
 
 }

--- a/new/client/pages/memories/memories.module.scss
+++ b/new/client/pages/memories/memories.module.scss
@@ -25,3 +25,6 @@
     }
 }
 
+.canvas {
+    display: none;
+}

--- a/new/client/pages/memories/memories.module.scss
+++ b/new/client/pages/memories/memories.module.scss
@@ -9,4 +9,17 @@
         width: 100%;
         
     }
+
+    button {
+        cursor: pointer;
+        font-size: 12px;
+        font-weight: 500;
+        height: 26px;
+        width: 80px;
+        border-radius: 6px;
+        background-color: white;
+        border: none;
+        margin-top: 20px;
+    }
 }
+

--- a/new/client/pages/memories/memories.module.scss
+++ b/new/client/pages/memories/memories.module.scss
@@ -28,3 +28,7 @@
 .canvas {
     display: none;
 }
+
+.error {
+    color: red;
+}

--- a/new/client/pages/memories/memories.module.scss
+++ b/new/client/pages/memories/memories.module.scss
@@ -10,13 +10,15 @@
         
     }
 
+
+    // Added button style from @/components/navbar/navbar.module.css
     button {
         cursor: pointer;
-        font-size: 12px;
+        font-size: 16px;
         font-weight: 500;
-        height: 26px;
-        width: 80px;
-        border-radius: 6px;
+        height: 34px;
+        width: 90px;
+        border-radius: 8px;
         background-color: white;
         border: none;
         margin-top: 20px;


### PR DESCRIPTION
All changes are seen on the /memories page.

Lets you save all memories into a zip, and you can choose to have each memory as separate primary/secondary images or as one merged "BeReal-style" image.

<img width="292" alt="image" src="https://github.com/s-alad/toofake/assets/128095876/4ce884d3-4d67-488a-9cbb-f1faa98e1c1f">


<img width="355" alt="image" src="https://github.com/s-alad/toofake/assets/128095876/43642a38-45dc-4dc3-9c1c-4533e1690888">



**New packages needed (run npm install in new/client after cloning):**
- jszip (working version: 3.10.1)
- file-saver (working version: 2.0.5)

**Some notes:**
- On the TooFake site itself, it seems that the memory dates are one day behind? If it gets fixed, remove line 170 of new/client/pages/memories/index.tsx
- In new/client/pages/memories/index.tsx: replace lines 185-191 with whatever CORS proxy method you use, request is a GET request to the memory's primary/secondary image URLs. Currently uses a free CORS proxy that's rate limited to 5 requests per second.
- Code was written in JS/HTML so convert to TS/React as needed

**Bugs:**
- For memories that aren't in cell-phone resolution (ex. Custom-uploaded through TooFake), the merged picture's secondary image doesn't follow aspect ratio like in the TooFake memory previews. Should also add changing border thickness based on image size?

<img width="253" alt="image" src="https://github.com/s-alad/toofake/assets/128095876/f8552d61-be54-424b-83f2-28920b93ac5f">


- **Rare:** For certain memories, their primary or secondary image is corrupted when fetched and can't be opened. This throws an InvalidStateException error when the image is used to create the merged memory image on memories/index.tsx: line 209-210. (Note that this only happened for 2 of 238 of my memories, and the morning after it was fine again)
