### PR TITLE
Added new headers to fix functionality

### DIFF
--- a/new/client/pages/api/add/post.ts
+++ b/new/client/pages/api/add/post.ts
@@ -133,7 +133,12 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
         // ============================================================================================
         // upload url
 
-        let upload_headers = { "authorization": "Bearer " + authorization_token, }
+        let upload_headers = {
+            "authorization": "Bearer " + authorization_token,
+            "bereal-app-version-code": "14549",
+            "bereal-signature": "berealsignature",
+            "bereal-device-id": "berealdeviceid",
+        }
 
         let upload_options = {
             url: "https://mobile.bereal.com/api/content/posts/upload-url?mimeType=image/webp",
@@ -155,12 +160,18 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
         let primary_path = primary_res.path;
         let primary_bucket = primary_res.bucket;
         primary_headers["Authorization"] = "Bearer " + authorization_token
+        primary_headers["bereal-app-version-code"] = "14549";
+        primary_headers["bereal-signature"] = "berealsignature";
+        primary_headers["bereal-device-id"] = "berealdeviceid";
 
         let secondary_headers = secondary_res.headers;
         let secondary_url = secondary_res.url;
         let secondary_path = secondary_res.path;
         let secondary_bucket = secondary_res.bucket;
         secondary_headers["Authorization"] = "Bearer " + authorization_token
+        secondary_headers["bereal-app-version-code"] = "14549";
+        secondary_headers["bereal-signature"] = "berealsignature";
+        secondary_headers["bereal-device-id"] = "berealdeviceid";
 
         // ============================================================================================
 
@@ -213,6 +224,9 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
         let post_headers = {
             "content-type": "application/json",
             "Authorization": "Bearer " + authorization_token,
+            "bereal-app-version-code": "14549",
+            "bereal-signature": "berealsignature",
+            "bereal-device-id": "berealdeviceid",
             "bereal-platform": "iOS",
             "bereal-os-version": "14.7.1",
             "accept-language": "en-US;q=1.0",

--- a/new/client/pages/api/add/realmoji.ts
+++ b/new/client/pages/api/add/realmoji.ts
@@ -79,7 +79,12 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
         // ============================================================================================
         // upload url
 
-        let upload_headers = { "authorization": "Bearer " + authorization_token,}
+        let upload_headers = {
+            "authorization": "Bearer " + authorization_token,
+            "bereal-app-version-code": "14549",
+            "bereal-signature": "berealsignature",
+            "bereal-device-id": "berealdeviceid",
+        }
 
         let upload_options = {
             url: "https://mobile.bereal.com/api/content/realmojis/upload-url?mimeType=image/webp",
@@ -99,7 +104,10 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
         let primary_url = primary_res.url;
         let primary_path = primary_res.path;
         let primary_bucket = primary_res.bucket;
-        primary_headers["Authorization"] = "Bearer " + authorization_token
+        primary_headers["Authorization"] = "Bearer " + authorization_token;
+        primary_headers["bereal-app-version-code"] = "14549";
+        primary_headers["bereal-signature"] = "berealsignature";
+        primary_headers["bereal-device-id"] = "berealdeviceid";
     
         // ============================================================================================
 
@@ -129,6 +137,9 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
         let post_headers = {
             "content-type": "application/json",
             "Authorization": "Bearer " + authorization_token,
+            "bereal-app-version-code": "14549",
+            "bereal-signature": "berealsignature",
+            "bereal-device-id": "berealdeviceid",
             "bereal-platform": "iOS",
             "bereal-os-version": "14.7.1",
             "accept-language": "en-US;q=1.0",

--- a/new/client/pages/api/all.ts
+++ b/new/client/pages/api/all.ts
@@ -15,6 +15,9 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
 
     let headers = {
         "authorization": "Bearer " + authorization_token,
+        "bereal-app-version-code": "14549",
+        "bereal-signature": "berealsignature",
+        "bereal-device-id": "berealdeviceid",
     }
 
     console.log("FETCING FEED")

--- a/new/client/pages/api/comment.ts
+++ b/new/client/pages/api/comment.ts
@@ -10,6 +10,9 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     console.log(authorization_token, instance_id, comment);
     let headers = {
         "authorization": "Bearer " + authorization_token,
+        "bereal-app-version-code": "14549",
+        "bereal-signature": "berealsignature",
+        "bereal-device-id": "berealdeviceid",
     }
     let body = {
         "content": comment,

--- a/new/client/pages/api/delete.ts
+++ b/new/client/pages/api/delete.ts
@@ -8,6 +8,9 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     console.log(authorization_token);
     let headers = {
         "authorization": "Bearer " + authorization_token,
+        "bereal-app-version-code": "14549",
+        "bereal-signature": "berealsignature",
+        "bereal-device-id": "berealdeviceid",
     }
 
     return axios.request({

--- a/new/client/pages/api/feed.ts
+++ b/new/client/pages/api/feed.ts
@@ -15,6 +15,9 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
 
     let headers = {
         "authorization": "Bearer " + authorization_token,
+        "bereal-app-version-code": "14549",
+        "bereal-signature": "berealsignature",
+        "bereal-device-id": "berealdeviceid",
     }
 
     console.log("FETCING FEED")

--- a/new/client/pages/api/friends.ts
+++ b/new/client/pages/api/friends.ts
@@ -7,6 +7,9 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     console.log(authorization_token);
     let headers = {
         "authorization": "Bearer " + authorization_token,
+        "bereal-app-version-code": "14549",
+        "bereal-signature": "berealsignature",
+        "bereal-device-id": "berealdeviceid",
     }
     return axios.request({
         url: "https://mobile.bereal.com/api" + "/relationships/friends",

--- a/new/client/pages/api/me.ts
+++ b/new/client/pages/api/me.ts
@@ -8,6 +8,9 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     console.log(authorization_token);
     let headers = {
         "authorization": "Bearer " + authorization_token,
+        "bereal-app-version-code": "14549",
+        "bereal-signature": "berealsignature",
+        "bereal-device-id": "berealdeviceid",
     }
 
     return axios.request({

--- a/new/client/pages/api/memories.ts
+++ b/new/client/pages/api/memories.ts
@@ -15,6 +15,9 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     console.log(authorization_token);
     let headers = {
         "authorization": "Bearer " + authorization_token,
+        "bereal-app-version-code": "14549",
+        "bereal-signature": "berealsignature",
+        "bereal-device-id": "berealdeviceid",
     }
     return axios.request({
         url: "https://mobile.bereal.com/api" + "/feeds/memories",

--- a/new/client/pages/api/profile.ts
+++ b/new/client/pages/api/profile.ts
@@ -9,6 +9,9 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     console.log(authorization_token, profile_id);
     let headers = {
         "authorization": "Bearer " + authorization_token,
+        "bereal-app-version-code": "14549",
+        "bereal-signature": "berealsignature",
+        "bereal-device-id": "berealdeviceid",
     }
 
     return axios.request({

--- a/new/client/pages/api/react.ts
+++ b/new/client/pages/api/react.ts
@@ -12,6 +12,9 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     console.log(authorization_token);
     let headers = {
         "authorization": "Bearer " + authorization_token,
+        "bereal-app-version-code": "14549",
+        "bereal-signature": "berealsignature",
+        "bereal-device-id": "berealdeviceid",
     }
 
     let data = {


### PR DESCRIPTION
Added the headers

`'bereal-app-version-code': '14549', 'bereal-signature': 'berealsignature', 'bereal-device-id': 'berealdeviceid',`

to all api endpoints that use authorization.
<br />

This is the solution used in rvaidun/befake@6ae70ca3ecd8b90c1563c5d3939caa8326ce1f10

I hope I didn't miss any but it should be an easy fix if I did.
In my brief testing, this fully restores functionality.

