### PR TITLE
update happy-headers dependency due to blocked device id

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -20,7 +20,7 @@
         "axios": "^1.4.0",
         "file-saver": "^2.0.5",
         "formidable": "^3.4.0",
-        "happy-headers": "^1.0.0",
+        "happy-headers": "^1.5.0",
         "heic-convert": "^1.2.4",
         "i18next": "^23.2.3",
         "jimp": "^0.22.8",
@@ -2385,9 +2385,9 @@
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="
     },
     "node_modules/happy-headers": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/happy-headers/-/happy-headers-1.2.0.tgz",
-      "integrity": "sha512-yALIo61K7iISFdXy9uEg59LvBeNw/2Ywy2Ytv7i4luJ1DT2A/n4btZHxCul14ix/LVmgV6jvdtnRMpPi4q4XEw=="
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/happy-headers/-/happy-headers-1.5.0.tgz",
+      "integrity": "sha512-uXJtYr2s3woBXhqQNpm3FW8UhHQ5LYz/qsH+UB2G2cTf7iaWOYrF3GJaknY0/Ocy3o/QuCa1wdMrLmExBJx9YQ=="
     },
     "node_modules/heic-convert": {
       "version": "1.2.4",
@@ -5613,9 +5613,9 @@
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="
     },
     "happy-headers": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/happy-headers/-/happy-headers-1.2.0.tgz",
-      "integrity": "sha512-yALIo61K7iISFdXy9uEg59LvBeNw/2Ywy2Ytv7i4luJ1DT2A/n4btZHxCul14ix/LVmgV6jvdtnRMpPi4q4XEw=="
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/happy-headers/-/happy-headers-1.5.0.tgz",
+      "integrity": "sha512-uXJtYr2s3woBXhqQNpm3FW8UhHQ5LYz/qsH+UB2G2cTf7iaWOYrF3GJaknY0/Ocy3o/QuCa1wdMrLmExBJx9YQ=="
     },
     "heic-convert": {
       "version": "1.2.4",

--- a/client/package.json
+++ b/client/package.json
@@ -21,7 +21,7 @@
     "axios": "^1.4.0",
     "file-saver": "^2.0.5",
     "formidable": "^3.4.0",
-    "happy-headers": "^1.0.0",
+    "happy-headers": "^1.5.0",
     "heic-convert": "^1.2.4",
     "i18next": "^23.2.3",
     "jimp": "^0.22.8",


### PR DESCRIPTION
BeReal seems to block the particular device id that this library is using. I updated it by changing one letter.
https://github.com/retoheusser/happy-headers/pull/4